### PR TITLE
restore time remaining time shown in UI

### DIFF
--- a/src/com/sheepit/client/Job.java
+++ b/src/com/sheepit/client/Job.java
@@ -211,7 +211,7 @@ import lombok.Getter;
 		if (isUseGPU() && configuration.getGPUDevice() != null && configuration.getComputeMethod() != ComputeType.CPU && OpenCL.TYPE
 				.equals(configuration.getGPUDevice().getType())) {
 			new_env.put("CYCLES_OPENCL_SPLIT_KERNEL_TEST", "1");
-			this.updateRenderingStatusMethod = UPDATE_METHOD_BY_TILE; // don't display remaining time
+			//this.updateRenderingStatusMethod = UPDATE_METHOD_BY_TILE; // hide remaining time in UI when openCL (why?)
 		}
 		
 		for (String arg : command1) {


### PR DESCRIPTION
When we compute openCL frames, blender engine(s) logs on the console output, remaining time.
But we were hiding the result for now. (Why?)
If every blender engines on every OS posts the same output, I see no reason to keep hiding it.